### PR TITLE
Python 3.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,11 @@ source_files = [
 zebra_scanner_module = Extension("zebra_scanner",
     include_dirs=[
         '/usr/include/zebra-scanner',
-        '/usr/include/python3.6',
         get_pybind_include(),
         src_path
     ],
     library_dirs=['/usr/lib/zebra-scanner/corescanner'],
-    libraries=['cs-client', 'cs-common', 'python3.6m', 'pugixml'],
+    libraries=['cs-client', 'cs-common', 'pugixml'],
     sources=source_files,
     extra_compile_args=['-Wno-deprecated', '-std=c++11', '-fvisibility=hidden']
 )


### PR DESCRIPTION
After removing the two reference to Python 3.6 it installs just fine on my Raspberry Pi OS (from Debian buster) with Python 3.7:

$ python3 setup.py install --prefix=$HOME/.local/

Thank you very much for writing this module!