### PR TITLE
Return numeric attribute values as numbers (not string)

### DIFF
--- a/src/BoostPythonCoreScanner.cpp
+++ b/src/BoostPythonCoreScanner.cpp
@@ -185,6 +185,7 @@ void CoreScanner::ParseScannerXML(pugi::xml_node& scanner) {
 	s.VID = scanner.child_value("VID");
 	s.modelnumber = scanner.child_value("modelnumber");
 	s.firmware = scanner.child_value("firmware");
+	trim(s.serialnumber);
 	trim(s.modelnumber);
 	trim(s.firmware);
 	s.DoM = scanner.child_value("DoM");
@@ -241,13 +242,21 @@ void Scanner::FetchAttributes(std::string attribute_list) {
 		a.id = std::stoi(attr.child_value("id"));
 		a.datatype = attr.child_value("datatype")[0];
 		a.permission = std::stoi(attr.child_value("permission"));
-		if(a.datatype=='F') {
+		// Information about data types is taken from zebra-scanner-4.4.1-8/Native/CsCommon/src/CsCommon.cpp
+		if (a.datatype=='F') { // Flag? A boolean
 			if(False.compare(attr.child_value("value")) == 0) {
 				a.value = py::cast(false);
 			} else {
 				a.value = py::cast(true);
 			}
-		} else {
+		}
+		else if (a.datatype=='B' || a.datatype=='W' || a.datatype=='D') { //uint8_t/uint16_t/uint32_t
+			a.value = py::cast(std::stoul(attr.child_value("value")));
+		}
+		else if (a.datatype=='I' || a.datatype=='L') { // int16_t/int32_t
+			a.value = py::cast(std::stol(attr.child_value("value")));
+		}
+		else { // String or single character
 			a.value = py::cast(attr.child_value("value"));
 		}
 		attributes[py::cast(a.id)] = a;


### PR DESCRIPTION
I have not found a textual description of the datatype in the attributes anywhere,
But in zebra-scanner-4.4.1-8/Native/CsCommon/src/CsCommon.cpp in the SDK there is a long if-elseif-...-else block that goes through the types.

With this patch the numeric datatypes are returned as integers instead of strings.