### PR TITLE
Segfault fix from MikaelBox

### DIFF
--- a/src/BoostPythonCoreScanner.cpp
+++ b/src/BoostPythonCoreScanner.cpp
@@ -472,6 +472,7 @@ void CoreScanner::OnBarcodeEvent(short int eventType, std::string & pscanData)
 		b.type = std::stoi(scanData.child_value("datatype"));
 		PyGILState_STATE state = PyGILState_Ensure();
 		py::object o = py::cast(b);
+		o.inc_ref();
 		s.OnBarcode(o);
 		PyGILState_Release(state);
 	}


### PR DESCRIPTION
Fix by MikaelBox from https://github.com/dayjaby/zebra-scanner/issues/22 issue.
Tested on Raspberry Pi4 Bullseye, Python 3.9.2. pybind11 version does not matter (tested both with latest v2.10.1 and pybind11 v2.5.0)
Edit: I removed scanner.__dict__ from the code because it gave an error. So maybe pybind11 version still matters. 
Segfault still happens at disconnect, but its usable for my purposes now.